### PR TITLE
Editorial: Use ClassElementName consistently

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -267,15 +267,15 @@ emu-example pre {
 
   <emu-grammar>
       MethodDefinition[Yield, Await] :
-        <del>PropertyName</del><ins>ClassElementName</ins>[?Yield, ?Await] `(` UniqueFormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
-        `get` <del>PropertyName</del><ins>ClassElementName</ins>[?Yield, ?Await] `(` `)` `{` FunctionBody[~Yield, ~Await] `}`
-        `set` <del>PropertyName</del><ins>ClassElementName</ins>[?Yield, ?Await] `(` PropertySetParameterList `)` `{` FunctionBody[~Yield, ~Await] `}`
+        ClassElementName[?Yield, ?Await] `(` UniqueFormalParameters[~Yield, ~Await] `)` `{` FunctionBody[~Yield, ~Await] `}`
+        `get` ClassElementName[?Yield, ?Await] `(` `)` `{` FunctionBody[~Yield, ~Await] `}`
+        `set` ClassElementName[?Yield, ?Await] `(` PropertySetParameterList `)` `{` FunctionBody[~Yield, ~Await] `}`
 
       GeneratorMethod[Yield, Await] :
-        `*` <del>PropertyName</del><ins>ClassElementName</ins>[?Yield, ?Await] `(` UniqueFormalParameters[+Yield, ~Await] `)` `{` GeneratorBody `}`
+        `*` ClassElementName[?Yield, ?Await] `(` UniqueFormalParameters[+Yield, ~Await] `)` `{` GeneratorBody `}`
 
       AsyncMethod[Yield, Await] :
-        `async` [no LineTerminator here] <del>PropertyName</del><ins>ClassElementName</ins>[?Yield, ?Await] `(` UniqueFormalParameters[~Yield, +Await] `)` `{` AsyncFunctionBody `}`
+        `async` [no LineTerminator here] ClassElementName[?Yield, ?Await] `(` UniqueFormalParameters[~Yield, +Await] `)` `{` AsyncFunctionBody `}`
   </emu-grammar>
   <emu-alg>
     1. Return PrivateBoundNames of |ClassElementName|.
@@ -424,7 +424,7 @@ emu-example pre {
     <emu-alg>
       1. Return ClassElementEvaluation of |MethodDefinition| with arguments _homeObject_, _enumerable_ and `"static"`.
     </emu-alg>
-    <emu-grammar>MethodDefinition : PropertyName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
+    <emu-grammar>MethodDefinition : ClassElementName `(` UniqueFormalParameters `)` `{` FunctionBody `}`</emu-grammar>
     <emu-alg>
       1. Let _methodDef_ be DefineMethod of |MethodDefinition| with argument _homeObject_.
       1. ReturnIfAbrupt(_methodDef_).
@@ -432,16 +432,16 @@ emu-example pre {
       1. <del>Let _desc_ be the PropertyDescriptor{[[Value]]: _methodDef_.[[Closure]], [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.</del>
       1. Return <del>? DefinePropertyOrThrow(_homeObject_, _methodDef_.[[Key]], _desc_).</del><ins>DefaultMethodDescriptor(_methodDef_.[[Key]], _methodDef_.[[Closure]], _enumerable_, _placement_).</ins>
     </emu-alg>
-    <emu-grammar>MethodDefinition : `get` PropertyName `(` `)` `{` FunctionBody `}`</emu-grammar>
+    <emu-grammar>MethodDefinition : `get` ClassElementName `(` `)` `{` FunctionBody `}`</emu-grammar>
     <emu-alg>
-      1. Let _propKey_ be the result of evaluating |PropertyName|.
-      1. ReturnIfAbrupt(_propKey_).
+      1. Let _key_ be the result of evaluating |ClassElementName|.
+      1. ReturnIfAbrupt(_key_).
       1. If the function code for this |MethodDefinition| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
       1. Let _scope_ be the running execution context's LexicalEnvironment.
       1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
       1. Let _closure_ be FunctionCreate(~Method~, _formalParameterList_, |FunctionBody|, _scope_, _strict_).
       1. Perform MakeMethod(_closure_, _homeObject_).
-      1. Perform SetFunctionName(_closure_, _propKey_, `"get"`).
+      1. Perform SetFunctionName(_closure_, _key_, `"get"`).
       1. <del>Let _desc_ be the PropertyDescriptor{[[Get]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.</del>
       1. <del>Return ? DefinePropertyOrThrow(_homeObject_, _propKey_, _desc_).</del>
       1. <ins>If _key_ is a Private Name,</ins>
@@ -454,15 +454,15 @@ emu-example pre {
       1. <ins>Let _element_ be the Record { [[Kind]]: `"method"`, [[Key]]: _key_, [[Descriptor]]: _desc_, [[Placement]]: _placement_ }</ins>
       1. <ins>Return a List containing _element_.</ins>
     </emu-alg>
-    <emu-grammar>MethodDefinition : `set` PropertyName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
+    <emu-grammar>MethodDefinition : `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
     <emu-alg>
-      1. Let _propKey_ be the result of evaluating |PropertyName|.
-      1. ReturnIfAbrupt(_propKey_).
+      1. Let _key_ be the result of evaluating |ClassElementName|.
+      1. ReturnIfAbrupt(_key_).
       1. If the function code for this |MethodDefinition| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
       1. Let _scope_ be the running execution context's LexicalEnvironment.
       1. Let _closure_ be FunctionCreate(~Method~, |PropertySetParameterList|, |FunctionBody|, _scope_, _strict_).
       1. Perform MakeMethod(_closure_, _homeObject_).
-      1. Perform SetFunctionName(_closure_, _propKey_, `"set"`).
+      1. Perform SetFunctionName(_closure_, _key_, `"set"`).
       1. <del>Let _desc_ be the PropertyDescriptor{[[Set]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.</del>
       1. <del>Return ? DefinePropertyOrThrow(_homeObject_, _propKey_, _desc_).</del>
       1. <ins>If _key_ is a Private Name,</ins>
@@ -475,10 +475,10 @@ emu-example pre {
       1. <ins>Let _element_ be the Record { [[Kind]]: `"method"`, [[Key]]: _key_, [[Descriptor]]: _desc_, [[Placement]]: _placement_ }</ins>
       1. <ins>Return a List containing _element_.</ins>
     </emu-alg>
-    <emu-grammar>GeneratorMethod : `*` PropertyName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
+    <emu-grammar>GeneratorMethod : `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
     <emu-alg>
-      1. Let _propKey_ be the result of evaluating |PropertyName|.
-      1. ReturnIfAbrupt(_propKey_).
+      1. Let _key_ be the result of evaluating |ClassElementName|.
+      1. ReturnIfAbrupt(_key_).
       1. If the function code for this |GeneratorMethod| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
       1. Let _scope_ be the running execution context's LexicalEnvironment.
       1. Let _closure_ be GeneratorFunctionCreate(~Method~, |UniqueFormalParameters|, |GeneratorBody|, _scope_, _strict_).
@@ -488,22 +488,22 @@ emu-example pre {
       1. <del>Perform SetFunctionName(_closure_, _propKey_).</del>
       1. <del>Let _desc_ be the PropertyDescriptor{[[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.</del>
       1. <del>Return ? DefinePropertyOrThrow(_homeObject_, _propKey_, _desc_).</del>
-      1. <ins>Return DefaultMethodDescriptor(_propKey_, _closure_, _enumerable_, _placement_).</ins>
+      1. <ins>Return DefaultMethodDescriptor(_key_, _closure_, _enumerable_, _placement_).</ins>
     </emu-alg>
     <emu-grammar>
-      AsyncMethod : `async` [no LineTerminator here] PropertyName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
+      AsyncMethod : `async` [no LineTerminator here] ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
     </emu-grammar>
     <emu-alg>
-      1. Let _propKey_ be the result of evaluating |PropertyName|.
-      1. ReturnIfAbrupt(_propKey_).
+      1. Let _key_ be the result of evaluating |ClassElementName|.
+      1. ReturnIfAbrupt(_key_).
       1. If the function code for this |AsyncMethod| is strict mode code, let _strict_ be *true*. Otherwise let _strict_ be *false*.
       1. Let _scope_ be the LexicalEnvironment of the running execution context.
       1. Let _closure_ be ! AsyncFunctionCreate(~Method~, |UniqueFormalParameters|, |AsyncFunctionBody|, _scope_, _strict_).
       1. Perform ! MakeMethod(_closure_, _homeObject_).
-      1. <del>Perform ! SetFunctionName(_closure_, _propKey_).</ins>
+      1. <del>Perform ! SetFunctionName(_closure_, _key_).</ins>
       1. <del>Let _desc_ be the PropertyDescriptor{[[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.</ins>
       1. <del>Return ? DefinePropertyOrThrow(_homeObject_, _propKey_, _desc_).</ins>
-      1. <ins>Return DefaultMethodDescriptor(_propKey_, _closure_, _enumerable_, _placement_).</ins>
+      1. <ins>Return DefaultMethodDescriptor(_key_, _closure_, _enumerable_, _placement_).</ins>
     </emu-alg>
 
   <emu-grammar>ClassElement : FieldDefinition `;`</emu-grammar>


### PR DESCRIPTION
This proposal updates the JS grammar to permit private names as
the names of methods. This patch fixes up some of the syntax-directed
observations to correctly refer to ClassElementName rather than
PropertyName, per the new grammar.

Closes #41