### PR TITLE
Editorial: Rename private name [[Descriptor]] to [[Attributes]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -334,7 +334,7 @@ emu-example pre {
       1. If _className_ is not *undefined*, then
         1. Perform _classScopeEnvRec_.InitializeBinding(_className_, _F_).
       1. Set _F_.[[Fields]] to _instanceFields_.
-      1. <ins>If PrivateBoundNames of |ClassBody| contains a Private Name _P_ such that the [[Type]] field of _P_'s [[Descriptor]] is either ~method~ or ~accessor~,</ins>
+      1. <ins>If PrivateBoundNames of |ClassBody| contains a Private Name _P_ such that the [[Kind]] field of _P_'s [[Attributes]] record is either ~method~ or ~accessor~,</ins>
         1. <ins>Set _F_.[[PrivateBrand]] to _proto_.</ins>
       1. Set the running execution context's PrivateNameEnvironment to _outerPrivateEnvironment_.
       1. Return _F_.
@@ -346,11 +346,11 @@ emu-example pre {
     <emu-alg>
       1. Perform SetFunctionName(_closure_, _key_).
       1. If _key_ is a Private Name,
-        1. Let _descriptor_ be _key_'s associated [[Descriptor]]
-        1. Assert: _descriptor_ does not have a [[Type]] field.
-        1. Set _descriptor_.[[Type]] to ~method~.
-        1. Set _descriptor_.[[Value]] to _closure.
-        1. Set _descriptor_.[[Brand]] to _homeObject_.
+        1. Let _attributes_ be _key_'s associated [[Attributes]] record.
+        1. Assert: _attributes_ does not have a [[Kind]] field.
+        1. Set _attributes_.[[Kind]] to ~method~.
+        1. Set _attributes_.[[Value]] to _closure.
+        1. Set _attributes_.[[Brand]] to _homeObject_.
       1. Else,
         1. Let _desc_ be the PropertyDescriptor{[[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.
         1. Perform ? DefinePropertyOrThrow(_homeObject_, _key_, _desc_).
@@ -360,7 +360,6 @@ emu-example pre {
   <emu-clause id="sec-method-definitions-runtime-semantics-classelementevaluation" aoid=ClassElementEvaluation>
     <h1>Runtime Semantics: ClassElementEvaluation</h1>
     <p>With parameters _homeObject_ and _enumerable_.</p>
-    <p>ClassElementEvaluation returns a List of Records of the form { [[Kind]]: `"method"` or `"field"`, [[Key]]: Property Key or Private Name, [[Descriptor]]: a Property Descriptor, [[Placement]]: `"static"`, `"prototype"` or `"own"`, [[Initializer]]: optional function for initial value which exists only for fields }.</p>
     <emu-see-also-para op="PropertyDefinitionEvaluation"></emu-see-also-para>
     <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
     <emu-alg>
@@ -390,16 +389,16 @@ emu-example pre {
       1. Perform MakeMethod(_closure_, _homeObject_).
       1. Perform SetFunctionName(_closure_, _key_, `"get"`).
       1. <ins>If _key_ is a Private Name,</ins>
-        1. <ins>Let _descriptor_ be _key_'s associated [[Descriptor]]</ins>
-        1. <ins>If _descriptor_ has a [[Type]] field,</ins>
-          1. <ins>Assert: _descriptor_.[[Type]] is ~accessor~.</ins>
-          1. <ins>Assert: _descriptor_.[[Brand]] is _homeObject_.</ins>
-          1. <ins>Assert: _descriptor_ does not have a [[Get]] field.</ins>
-          1. <ins>Set _descriptor_.[[Get]] to _closure_.</ins>
+        1. <ins>Let _attributes_ be _key_'s associated [[Attributes]] record</ins>
+        1. <ins>If _attributes_ has a [[Kind]] field,</ins>
+          1. <ins>Assert: _attributes_.[[Kind]] is ~accessor~.</ins>
+          1. <ins>Assert: _attributes_.[[Brand]] is _homeObject_.</ins>
+          1. <ins>Assert: _attributes_ does not have a [[Get]] field.</ins>
+          1. <ins>Set _attributes_.[[Get]] to _closure_.</ins>
         1. <ins>Otherwise,</ins>
-          1. <ins>Set _descriptor_.[[Type]] to ~accessor~.</ins>
-          1. <ins>Set _descriptor_.[[Brand]] to _homeObject_.</ins>
-          1. <ins>Set _descriptor_.[[Get]] to _closure_.</ins>
+          1. <ins>Set _attributes_.[[Kind]] to ~accessor~.</ins>
+          1. <ins>Set _attributes_.[[Brand]] to _homeObject_.</ins>
+          1. <ins>Set _attributes_.[[Get]] to _closure_.</ins>
       1. <ins>Else,</ins>
         1. Let _desc_ be the PropertyDescriptor{[[Get]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.
         1. Perform ? DefinePropertyOrThrow(_homeObject_, _key_, _desc_).
@@ -414,16 +413,16 @@ emu-example pre {
       1. Perform MakeMethod(_closure_, _homeObject_).
       1. Perform SetFunctionName(_closure_, _key_, `"set"`).
       1. <ins>If _key_ is a Private Name,</ins>
-        1. <ins>Let _descriptor_ be _key_'s associated [[Descriptor]]</ins>
-        1. <ins>If _descriptor_ has a [[Type]] field,</ins>
-          1. <ins>Assert: _descriptor_.[[Type]] is ~accessor~.</ins>
-          1. <ins>Assert: _descriptor_.[[Brand]] is _homeObject_.</ins>
-          1. <ins>Assert: _descriptor_ does not have a [[Set]] field.</ins>
-          1. <ins>Set _descriptor_.[[Set]] to _closure_.</ins>
+        1. <ins>Let _attributes_ be _key_'s associated [[Attributes]] record</ins>
+        1. <ins>If _attributes_ has a [[Kind]] field,</ins>
+          1. <ins>Assert: _attributes_.[[Kind]] is ~accessor~.</ins>
+          1. <ins>Assert: _attributes_.[[Brand]] is _homeObject_.</ins>
+          1. <ins>Assert: _attributes_ does not have a [[Set]] field.</ins>
+          1. <ins>Set _attributes_.[[Set]] to _closure_.</ins>
         1. <ins>Otherwise,</ins>
-          1. <ins>Set _descriptor_.[[Type]] to ~accessor~.</ins>
-          1. <ins>Set _descriptor_.[[Brand]] to _homeObject_.</ins>
-          1. <ins>Set _descriptor_.[[Set]] to _closure_.</ins>
+          1. <ins>Set _attributes_.[[Kind]] to ~accessor~.</ins>
+          1. <ins>Set _attributes_.[[Brand]] to _homeObject_.</ins>
+          1. <ins>Set _attributes_.[[Set]] to _closure_.</ins>
       1. <ins>Else,</ins>
         1. Let _desc_ be the PropertyDescriptor{[[Set]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true*}.
         1. Perform ? DefinePropertyOrThrow(_homeObject_, _key_, _desc_).
@@ -543,8 +542,8 @@ emu-example pre {
 <emu-clause id="sec-private-names">
   <h1>Private Names and references</h1>
 
-  <p>Each PrivateName value immutably holds a mutable record called [[Descriptor]], initially empty, which may have the following fields added to it:</p>
-    <emu-table id="private-name-record" caption="Fields of the [[Descriptor]] record">
+  <p>Each PrivateName value immutably holds a mutable record called [[Attributes]], initially empty, which may have the following fields added to it:</p>
+    <emu-table id="private-name-record" caption="Fields of the [[Attributes]] record">
       <table>
         <tbody>
         <tr>
@@ -563,7 +562,7 @@ emu-example pre {
         </tr>
         <tr>
           <td>
-            [[Type]]
+            [[Kind]]
           </td>
           <td>
             ~field~, ~method~ or ~accessor~
@@ -659,8 +658,8 @@ emu-example pre {
 <emu-clause id="sec-privatebrandcontains" aoid="PrivateBrandContains">
   <h1>PrivateBrandCheck(_O_, _P_)</h1>
   <emu-alg>
-    1. Let _descriptor_ be _P_'s associated [[Descriptor]].
-    1. If _O_.[[PrivateBrands]] does not contain an entry _e_ such that SameValue(_e_, _descriptor_.[[Brand]]) is *true*,
+    1. Let _attributes_ be _P_'s associated [[Attributes]] record.
+    1. If _O_.[[PrivateBrands]] does not contain an entry _e_ such that SameValue(_e_, _attributes_.[[Brand]]) is *true*,
       1. Throw a *TypeError* exception.
   </emu-alg>
 </emu-clause>
@@ -679,17 +678,17 @@ emu-example pre {
   <emu-alg>
     1. Assert: _P_ is a Private Name value.
     1. If _O_ is not an object, throw a *TypeError* exception.
-    1. <ins>Let _descriptor_ be _P_'s associated [[Descriptor]].</ins>
-    1. <ins>If _descriptor_.[[Type]] is ~field~,
+    1. <ins>Let _attributes_ be _P_'s associated [[Attributes]] record.</ins>
+    1. <ins>If _attributes_.[[Kind]] is ~field~,
       1. Let _entry_ be PrivateFieldFind(_P_, _O_).
       1. If _entry_ is ~empty~, throw a *TypeError* exception.
       1. Return _entry_.[[PrivateFieldValue]].
     1. <ins>Perform ? PrivateBrandCheck(_O_, _P_).</ins>
-    1. <ins>If _descriptor_.[[Type]] is ~method~,</ins>
-      1. <ins>Return _descriptor_.[[Value]].</ins>
-    1. <ins>Otherwise, _descriptor_.[[Type]] is ~accessor~,</ins>
-      1. <ins>If _descriptor_ does not have a [[Get]] field, throw a *TypeError* exception.</ins>
-      1. <ins>Let _getter_ be _descriptor_.[[Get]].</ins>
+    1. <ins>If _attributes_.[[Kind]] is ~method~,</ins>
+      1. <ins>Return _attributes_.[[Value]].</ins>
+    1. <ins>Otherwise, _attributes_.[[Kind]] is ~accessor~,</ins>
+      1. <ins>If _attributes_ does not have a [[Get]] field, throw a *TypeError* exception.</ins>
+      1. <ins>Let _getter_ be _attributes_.[[Get]].</ins>
       1. <ins>Return ? Call(_getter_, _O_).</ins>
   </emu-alg>
 </emu-clause>
@@ -699,17 +698,17 @@ emu-example pre {
   <emu-alg>
     1. Assert: _P_ is a Private Name value.
     1. If _O_ is not an object, throw a *TypeError* exception.
-    1. <ins>Let _descriptor_ be _P_'s associated [[Descriptor]].</ins>
-    1. <ins>If _descriptor_.[[Type]] is ~field~,
+    1. <ins>Let _attributes_ be _P_'s associated [[Attributes]] record.</ins>
+    1. <ins>If _attributes_.[[Kind]] is ~field~,
       1. Let _entry_ be PrivateFieldFind(_P_, _O_).
       1. If _entry_ is ~empty~, throw a *TypeError* exception.
       1. Set _entry_.[[PrivateFieldValue]] to _value_.
       1. <ins>Return.</ins>
-    1. <ins>If _descriptor_.[[Type]] is ~method~, throw a *TypeError* exception.</ins>
-    1. <ins>Otherwise, _descriptor_.[[Type]] is ~accessor~,</ins>
-      1. <ins>If _O_.[[PrivateFieldBrands]] does not contain _descriptor_.[[Brand]], throw a *TypeError* exception.</ins>
-      1. <ins>If _descriptor_ does not have a [[Set]] field, throw a *TypeError* exception.</ins>
-      1. <ins>Let _setter_ be _descriptor_.[[Set]].</ins>
+    1. <ins>If _attributes_.[[Kind]] is ~method~, throw a *TypeError* exception.</ins>
+    1. <ins>Otherwise, _attributes_.[[Kind]] is ~accessor~,</ins>
+      1. <ins>If _O_.[[PrivateFieldBrands]] does not contain _attributes_.[[Brand]], throw a *TypeError* exception.</ins>
+      1. <ins>If _attributes_ does not have a [[Set]] field, throw a *TypeError* exception.</ins>
+      1. <ins>Let _setter_ be _attributes_.[[Set]].</ins>
       1. <ins>Perform ? Call(_setter_, _O_, _value_).</ins>
       1. <ins>Return.</ins>
   </emu-alg>


### PR DESCRIPTION
And rename [[Type]] to [[Kind]] to match decorators