### PR TITLE
Add a badge for specifying current stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Private methods and getter/setters for JavaScript classes
 
+![Stage 3](https://badges.aleen42.com/src/tc39_4.svg)
+
 Daniel Ehrenberg
 
 [Stage 3](https://tc39.es/process-document/)


### PR DESCRIPTION
According to https://es.discourse.group/t/a-standard-badge-for-tc39/731, automatically generate a badge for specifying current stage of the proposal.